### PR TITLE
[TASK] maintain php 7.2 compatibility

### DIFF
--- a/Classes/Hooks/Form.php
+++ b/Classes/Hooks/Form.php
@@ -20,7 +20,10 @@ class Form
 {
     const FIELD_ID = 'cr-field';
 
-    private LoggerInterface $logger;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
 
     public function __construct()
     {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "GPL-2.0-or-later"
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "typo3/cms-core": "^10.4.29 || ^11.5",
         "typo3/cms-extbase": "^10.4.29 || ^11.5",
         "typo3/cms-form": "^10.4.29 || ^11.5",


### PR DESCRIPTION
TYPO3 10 LTS has a php platform requirement of `^7.2`. It is easy to honor that. I suggest to drop v10 support after April 2023 anyways.