### PR TITLE
[FEATURE] Make extension setting for added time

### DIFF
--- a/Classes/Hooks/Form.php
+++ b/Classes/Hooks/Form.php
@@ -84,7 +84,7 @@ class Form
             return '';
         }
 
-        if ((int)$expirationTime <= time()) {
+        if ((int)($expirationTime + intval($extensionSettings['crAdditionalExpiration'] ?? 3600)) <= time()) {
             $this->logger->debug('CR response expired. Submitted data', $requestArguments);
             return '';
         }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -2,3 +2,5 @@
 ###########################
 # cat=settings/enable/10; type=integer; label=Delay in seconds when response calculation is set using JavaScript
 	crJavaScriptDelay = 3
+# cat=settings/enable/20; type=integer; label=Additional time in seconds to add on to page lifetime
+	crAdditionalExpiration = 3600


### PR DESCRIPTION
To extend expiration time past the cache timeout. 

Tying the expiration time to cache timeout is detrimental for pages where the cache timeout is set to a short time (e.g. one minute). In this instance, the user is unable to submit the form before the challenge expires. This PR should make it possible to successfully submit forms on pages with a short cache time, using a default additional time of 1 hour. 