### PR TITLE
[TASK] Exclude several files and folders from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/.Build export-ignore
+/.github export-ignore
+/Tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/ext_emconf.php export-ignore


### PR DESCRIPTION
Several development-only files and folders as well as files which are exclusively relevant for classic mode installations (`ext_emconf.php`) are now excluded from dist archives. This limits the number of files delivered by e.g. installing the extension via Composer.