### PR TITLE
[BUGFIX] Correct Codeception output paths for artifact upload

### DIFF
--- a/.github/workflows/AcceptanceTests.yml
+++ b/.github/workflows/AcceptanceTests.yml
@@ -84,7 +84,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: codeception-results
-          path: Tests/Acceptance/_output/
+          path: |
+            Tests/Acceptance/WithChromeBrowser/_output/
+            Tests/Acceptance/WithPhpBrowser/_output/
 
       - name: Upload logs
         if: ${{ failure() }}


### PR DESCRIPTION
Codeception outputs are written to dedicated subdirectories, depending on the selected test suite. This PR reflects the path structure for artifact upload.